### PR TITLE
Update task release proto for publish change signals and deployed_at

### DIFF
--- a/apis/workflows/v1/task_release.proto
+++ b/apis/workflows/v1/task_release.proto
@@ -5,6 +5,7 @@ edition = "2023";
 package workflows.v1;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
 import "tilebox/v1/id.proto";
 import "workflows/v1/core.proto";
 
@@ -32,8 +33,19 @@ message PublishReleaseResponse {
   tilebox.v1.ID release_id = 1;
   // True when this call created a new release row.
   bool created = 2;
-  // True when this call matched an existing immutable payload exactly.
-  bool idempotent = 3;
+  // Explicit payload changes compared to the latest comparable release.
+  PublishReleaseChanges changes = 4;
+  reserved 3;
+}
+
+// PublishReleaseChanges captures which release surfaces changed.
+message PublishReleaseChanges {
+  // True when the task set (including versions) changed.
+  bool tasks = 1;
+  // True when the artifact content changed.
+  bool artifact = 2;
+  // True when the runtime environment changed.
+  bool environment = 3;
 }
 
 // DeployReleaseRequest updates the cluster deployment pointer for a release.
@@ -82,6 +94,8 @@ message DeployedRelease {
   uint64 change_revision = 7;
   // Task identifiers included in the deployed release.
   repeated TaskIdentifier tasks = 8;
+  // Timestamp when this release pointer was deployed.
+  google.protobuf.Timestamp deployed_at = 9;
 }
 
 // GetClusterDeploymentManifestResponse returns desired deployment state for a cluster.

--- a/apis/workflows/v1/task_release.proto
+++ b/apis/workflows/v1/task_release.proto
@@ -35,6 +35,7 @@ message PublishReleaseResponse {
   bool created = 2;
   // Explicit payload changes compared to the latest comparable release.
   PublishReleaseChanges changes = 4;
+  reserved idempotent;
   reserved 3;
 }
 


### PR DESCRIPTION
## Summary
- remove `PublishReleaseResponse.idempotent`
- add structured `PublishReleaseChanges` with `tasks`, `artifact`, and `environment`
- add `deployed_at` timestamp to `DeployedRelease`

## Context
Part of TBX-2878 to improve publish/deploy observability and CI decisioning.

## Notes
This PR only updates API proto definitions in `tilebox/api`. Core service/CLI implementation is in a separate core PR.
